### PR TITLE
chore: SOP for external metadata sync

### DIFF
--- a/docs/operation/sop/MM.1/MM.1-SyncExternalMetadata.md
+++ b/docs/operation/sop/MM.1/MM.1-SyncExternalMetadata.md
@@ -77,5 +77,5 @@ Replace `THE_URL` with your actual presigned URL.
 
 ## References
 
-- [API Documentation](../../README.md#api)
-- [CSV Loader Implementation](../proc/service/load_csv_srv.py)
+- [API Documentation](../../../../metadata-manager/README.md#api)
+- [CSV Loader Implementation](../../../../metadata-manager/proc/service/load_csv_srv.py)

--- a/metadata-manager/README.md
+++ b/metadata-manager/README.md
@@ -145,7 +145,7 @@ Please refer to the [tracking-sheet-service](proc/service/tracking_sheet_srv.py)
 
 ### Custom CSV File Loader
 
-For the manual sync procedure, see [docs/SOP/MM.1-SyncExternalMetadata.md](./docs/SOP/MM.1-SyncExternalMetadata.md).
+For the manual sync procedure, see [MM.1-SyncExternalMetadata.md](../docs/operation/sop/MM.1/MM.1-SyncExternalMetadata.md).
 
 ### Audit Data
 


### PR DESCRIPTION
Move custom CSV loader docs to `./docs/SOP`